### PR TITLE
Pad left with zero

### DIFF
--- a/xarrayutils/vertical_coordinates.py
+++ b/xarrayutils/vertical_coordinates.py
@@ -250,7 +250,7 @@ def linear_interpolation_regrid(
                 "When `z_bounds` is given, `z_bounds_dim` has to be specified"
             )
         else:
-            pad_left = z_bounds[{z_bounds_dim: 0}]
+            pad_left = 0
             pad_right = z_bounds[{z_bounds_dim: -1}]
 
     kwargs = dict(


### PR DESCRIPTION
In almost all situations, the first entry in the z_bounds vector should be zero, not the same as the second entry. Hence, I think we should pad left with zero (this matters a lot for generating thickness weights).