### PR TITLE
Try to install without manually installing requirements

### DIFF
--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -77,13 +77,7 @@ jobs:
           sleep 10
           python -m pip install --upgrade pip
           pip cache purge
-          # This is kind of stupid, but the only way I got this to work with the latest versions on testpypi
-          # If I used: python -m pip install --extra-index-url https://test.pypi.org/simple --upgrade xarrayutils
-          # It would grab an older cmip6_pp version and with `--index-url=...` I cant get the proper dependencies from pypi
-          # So I am installing the dependencies manually from pypi and the newest version from testpypi...not sure if this
-          # defeats the purpose, but I am frankly fed up with this shit!
-          python -m pip install xgcm xarray numpy pandas cftime
-          python -m pip install --index-url https://test.pypi.org/simple --upgrade xarrayutils
+          python -m pip install --extra-index-url https://test.pypi.org/simple --upgrade xarrayutils
           python -c "import xarrayutils;print(xarrayutils.__version__)"
   upload-to-pypi:
     needs: test-built-dist


### PR DESCRIPTION
Over at [cmip6_preprocessing](https://github.com/jbusecke/cmip6_preprocessing) I had to [manually install](https://github.com/jbusecke/cmip6_preprocessing/blob/8d0dec14ac1e98e5c981bdf7859a8e90faac99b9/.github/workflows/pythonpublish.yaml#L82-L88) dependencies for the package. I am trying to revert this here, lets see if that works.