### PR TITLE
Check uploaded version for testpypi and pypi seperately

### DIFF
--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -70,21 +70,6 @@ jobs:
           password: ${{ secrets.TESTPYPI_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
           verbose: true
-      # - name: Setup upterm session
-      #   uses: lhotari/action-upterm@v1
-      - name: Check uploaded package
-        run: |
-          sleep 10
-          python -m pip install --upgrade pip
-          pip cache purge
-          # This is kind of stupid, but the only way I got this to work with the latest versions on testpypi
-          # If I used: python -m pip install --extra-index-url https://test.pypi.org/simple --upgrade xarrayutils
-          # It would grab an older cmip6_pp version and with `--index-url=...` I cant get the proper dependencies from pypi
-          # So I am installing the dependencies manually from pypi and the newest version from testpypi...not sure if this
-          # defeats the purpose, but I am frankly fed up with this shit!
-          python -m pip install xarray dask numpy scipy
-          python -m pip install --index-url https://test.pypi.org/simple --upgrade xarrayutils
-          python -c "import xarrayutils;print(xarrayutils.__version__)"
   upload-to-pypi:
     needs: test-built-dist
     if: "!github.event.release.prerelease"
@@ -100,3 +85,28 @@ jobs:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
           verbose: true
+  check-version-testpypi:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Check uploaded testpypi package
+          run: |
+            sleep 10
+            python -m pip install --upgrade pip
+            pip cache purge
+            # This is kind of stupid, but the only way I got this to work with the latest versions on testpypi
+            # If I used: python -m pip install --extra-index-url https://test.pypi.org/simple --upgrade xarrayutils
+            # It would grab an older cmip6_pp version and with `--index-url=...` I cant get the proper dependencies from pypi
+            # So I am installing the dependencies manually from pypi and the newest version from testpypi...not sure if this
+            # defeats the purpose, but I am frankly fed up with this shit!
+            python -m pip install xarray dask numpy scipy
+            python -m pip install --index-url https://test.pypi.org/simple --upgrade xarrayutils
+            python -c "import xarrayutils;print(xarrayutils.__version__)"
+  check-version-pypi:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Check uploaded pypi package
+          run: |
+            python -m pip install --upgrade pip
+            python -m pip install --upgrade xarrayutils
+            python -c "import xarrayutils;print(xarrayutils.__version__)"
+        


### PR DESCRIPTION
Check uploaded version for testpypi and pypi seperately. 

I had problems with this lately (would download a previous version). I hope coupling this out might help. It will also give an overview which version is installed on which index after each (pre)release.