### PR TITLE
Restrict pandoc<3.0.0

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -23,7 +23,7 @@ dependencies:
   - nbsphinx
   - jupyter_client
   - sphinxcontrib-srclinks
-  - pandoc
+  - pandoc<3.0.0
   - recommonmark
   - pip
   - pip:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Got errors in the doc build [here](https://readthedocs.org/projects/xarrayutils/builds/20947822/), and [here](https://readthedocs.org/projects/xarrayutils/builds/20889037/). I am not sure why this does not get resolved by conda. Testing this to see if that works as a quick fix.

 - [ ] Closes #xxxx
 - [ ] Tests added
 - [ ] Passes `pre-commit run --all-files`
 - [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - [ ] New functions/methods are listed in `api.rst`
