### PR TITLE
Remove unused import of tkinter

### DIFF
--- a/xarrayutils/plotting.py
+++ b/xarrayutils/plotting.py
@@ -1,4 +1,3 @@
-from tkinter import Y
 import numpy as np
 import xarray as xr
 import warnings


### PR DESCRIPTION
I think this is unused, and looking at the [PR in which it was introduced](https://github.com/jbusecke/xarrayutils/pull/123/files#diff-d0c8920964778bf2572228369b69e02d33ebd43946343ba450fee725df94f36eR1) suggests it was added by autocomplete unless I am missing something subtle. Python installed by homebrew doesn't have tk by default so this was causing an error.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Passes `pre-commit run --all-files`
